### PR TITLE
Refactor: Standardize action buttons across all tables

### DIFF
--- a/src/components/categoriasGastos/CategoriasGastosTable.vue
+++ b/src/components/categoriasGastos/CategoriasGastosTable.vue
@@ -60,19 +60,14 @@
                 @click="editCategoriaGasto(categoria)"
                 title="Editar"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                  <path d="M5.433 13.917l1.262-3.155A4 4 0 017.58 9.42l6.92-6.918a2.121 2.121 0 013 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 01-.65-.65z" />
-                  <path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0010 3H4.75A2.75 2.75 0 002 5.75v9.5A2.75 2.75 0 004.75 18h9.5A2.75 2.75 0 0017 15.25V10a.75.75 0 00-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5z" />
-                </svg>
+                <IconEdit size="16" />
               </button>
               <button 
                 class="action-button delete-button" 
                 @click="deleteCategoriaGasto(categoria)"
                 title="Excluir"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                  <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
-                </svg>
+                <IconDelete size="16" />
               </button>
             </div>
           </td>
@@ -104,19 +99,16 @@
               @click="editCategoriaGasto(categoria)"
               title="Editar"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                <path d="M5.433 13.917l1.262-3.155A4 4 0 017.58 9.42l6.92-6.918a2.121 2.121 0 013 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 01-.65-.65z" />
-                <path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0010 3H4.75A2.75 2.75 0 002 5.75v9.5A2.75 2.75 0 004.75 18h9.5A2.75 2.75 0 0017 15.25V10a.75.75 0 00-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5z" />
-              </svg>
+              <IconEdit size="20" />
+              <span>Editar</span>
             </button>
             <button 
               class="card-action-button delete-button" 
               @click="deleteCategoriaGasto(categoria)"
               title="Excluir"
             >
-              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
-              </svg>
+              <IconDelete size="20" />
+              <span>Excluir</span>
             </button>
           </div>
         </div>
@@ -158,6 +150,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { CategoriaGasto } from '@/types/categoriaGasto.types'
+
+import IconEdit from '@/components/icons/IconEdit.vue';
+import IconDelete from '@/components/icons/IconDelete.vue';
 
 // Props
 const props = defineProps<{
@@ -250,7 +245,7 @@ const sortTable = (field: string) => {
   display: inline-block;
   width: 16px;
   height: 16px;
-  border-radius: 4px;
+  border-radius: 4px; // Assuming $border-radius or direct value
   margin-right: $spacing-xs;
   vertical-align: middle;
   border: 1px solid rgba(0, 0, 0, 0.1);
@@ -276,44 +271,89 @@ const sortTable = (field: string) => {
 
 .action-buttons {
   display: flex;
-  gap: $spacing-xs;
+  gap: $spacing-xxs; // Use smaller gap for desktop buttons
+  justify-content: center;
 }
 
 .action-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 5px; // Direct value for precision
+  border-radius: 4px; // Direct value for precision
+  color: $text-gray-medium; // Assuming this is #6b7280
+  transition: all 0.2s; // Direct value for precision
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+
+  // Targets SVG within IconEdit/IconDelete components
+  ::v-deep(svg) { // Using ::v-deep for robustness with scoped styles
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+// Specific hover states for DESKTOP action buttons
+.action-buttons {
+  .edit-button:hover {
+    background-color: #dbeafe; // Hex for consistency with ClientsTable/ObrasTable
+    color: #1e40af;      // Hex for consistency with ClientsTable/ObrasTable
+  }
+
+  .delete-button:hover {
+    background-color: #fee2e2; // Hex for consistency with ClientsTable/ObrasTable
+    color: #b91c1c;      // Hex for consistency with ClientsTable/ObrasTable
+  }
+}
+
+
+// Styles for MOBILE CARD action buttons
+.card-action-button {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
-  border: none;
-  border-radius: $border-radius;
+  width: auto; // Accommodate icon + text
+  height: auto; // Accommodate icon + text
+  padding: $spacing-xs; // Should be ~0.5rem
+  gap: $spacing-xxs; // Should be ~0.25rem, for space between icon and text
+  border: 1px solid $border-color;
+  border-radius: $border-radius; // Should be 4px
   cursor: pointer;
-  transition: background-color $transition-speed;
+  transition: background-color $transition-speed; // Should be 0.2s
+  background-color: white;
+
+  // Targets SVG within IconEdit/IconDelete components used in cards
+  ::v-deep(svg) { // Using ::v-deep for robustness
+    width: 1.25rem; // Corresponds to size="20"
+    height: 1.25rem; // Corresponds to size="20"
+  }
+
+  span {
+    font-size: $font-size-sm; // Should be ~0.75rem
+  }
 }
 
-.action-button svg {
-  width: 16px;
-  height: 16px;
-}
-
+// Base styles for MOBILE card action buttons (specific colors)
 .card-action-button.edit-button {
   background-color: rgba($primary-color, 0.1);
   color: $primary-color;
-  border-color: $primary-color;
-}
-
-.edit-button:hover {
-  background-color: rgba($primary-color, 0.2);
 }
 
 .card-action-button.delete-button {
   background-color: rgba($error-color, 0.1);
   color: $error-color;
-  border-color: $error-color;
 }
 
-.delete-button:hover {
-  background-color: rgba($error-color, 0.2);
+// Hover states for MOBILE card action buttons
+.card-action-button.edit-button:hover {
+  background-color: rgba($primary-color, 0.2); // Darken the background
+}
+
+.card-action-button.delete-button:hover {
+  background-color: rgba($error-color, 0.2); // Darken the background
 }
 
 .empty-message {

--- a/src/components/clients/ClientsTable.vue
+++ b/src/components/clients/ClientsTable.vue
@@ -74,24 +74,28 @@
             <td>{{ client.address || '-' }}</td>
             <td class="actions-cell" 
             :style="{ position: clients.length === clients.indexOf(client) + 1 ? 'absolute' : '', borderBottom: clients.length === clients.indexOf(client) + 1 ? 'none' : '' }">
-              <div class="actions-menu">
-                <button class="actions-button" @click="toggleMenu(client.id)">
-                  <IconEllipsis size="18" />
+              <div class="action-buttons">
+                <button
+                  class="action-button view-button"
+                  @click="handleView(client.id)"
+                  title="Visualizar"
+                >
+                  <IconView size="16" />
                 </button>
-                <div v-if="activeMenu === client.id" class="actions-dropdown">
-                    <div class="dropdown-item" @click="handleView(client.id)">
-                      <IconView />
-                      <span>Visualizar</span>
-                    </div>
-                    <div class="dropdown-item" @click="handleEdit(client.id)">
-                      <IconEdit />
-                      <span>Editar</span>
-                    </div>
-                    <div class="dropdown-item delete" @click="handleDelete(client.id)">
-                      <IconDelete />
-                      <span>Excluir</span>
-                    </div>
-                  </div>
+                <button
+                  class="action-button edit-button"
+                  @click="handleEdit(client.id)"
+                  title="Editar"
+                >
+                  <IconEdit size="16" />
+                </button>
+                <button
+                  class="action-button delete-button"
+                  @click="handleDelete(client.id)"
+                  title="Excluir"
+                >
+                  <IconDelete size="16" />
+                </button>
               </div>
             </td>
           </tr>
@@ -125,7 +129,7 @@ import type { Client, PaginationLinks } from '@/types/client.types'
 import Pagination from '@/components/common/Pagination.vue'
 import ConfirmationModal from '@/components/common/ConfirmationModal.vue'
 import IconSort from '@/components/icons/IconSort.vue'
-import IconEllipsis from '@/components/icons/IconEllipsis.vue'
+// IconEllipsis import removed as it's no longer used
 import IconView from '@/components/icons/IconView.vue'
 import IconEdit from '@/components/icons/IconEdit.vue'
 import IconDelete from '@/components/icons/IconDelete.vue'
@@ -160,44 +164,13 @@ const emit = defineEmits<{
   (e: 'delete', clientId: number): void;
 }>()
 
-// Controle do menu de ações
-const activeMenu = ref<number | null>(null)
-const toggleMenu = (clientId: number) => {
-  if (activeMenu.value === clientId) {
-    activeMenu.value = null
-  } else {
-    activeMenu.value = clientId
-  }
-}
-
-// Fechar o menu quando clicar fora dele
-const closeMenuOnClickOutside = (event: MouseEvent) => {
-  if (activeMenu.value !== null) {
-    const target = event.target as HTMLElement
-    if (!target.closest('.actions-menu')) {
-      activeMenu.value = null
-    }
-  }
-}
-
-// Adicionar e remover o listener quando o componente é montado/desmontado
-onMounted(() => {
-  document.addEventListener('click', closeMenuOnClickOutside)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', closeMenuOnClickOutside)
-})
-
 // Ações do menu
 const handleView = (clientId: number) => {
   router.push({ name: 'client-details', params: { id: clientId.toString() } })
-  activeMenu.value = null
 }
 
 const handleEdit = (clientId: number) => {
   router.push({ name: 'edit-client', params: { id: clientId.toString() } })
-  activeMenu.value = null
 }
 
 const handleDelete = (clientId: number) => {
@@ -207,7 +180,6 @@ const handleDelete = (clientId: number) => {
     clientToDelete.value = client
     showDeleteModal.value = true
   }
-  activeMenu.value = null
 }
 
 const confirmDelete = async () => {
@@ -389,65 +361,53 @@ const formatDate = (dateString: string): string => {
 
 .actions-cell {
   text-align: center;
-  position: relative;
-  overflow: visible;
+  /* position: relative; and overflow: visible; removed as they are no longer needed for the dropdown */
 }
 
-.actions-menu {
-  position: relative;
-  display: inline-block;
+.action-buttons {
+  display: flex;
+  gap: 0; /* Or a small gap if preferred, ObrasTable.vue has 0 */
+  justify-content: center; /* Center buttons within the cell */
 }
 
-.actions-button {
+.action-button {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 5px;
-  border-radius: 4px;
-  color: #6b7280;
+  padding: 5px; /* Adjust as needed */
+  border-radius: 4px; /* Or other border-radius */
+  color: #6b7280; /* Default icon color */
   transition: all 0.2s;
-}
-
-.actions-button:hover {
-  background-color: #f3f4f6;
-  color: #111827;
-}
-
-.actions-dropdown {
-  position: absolute;
-  right: 0;
-  /* Alterar o posicionamento para que o menu abra para baixo */
-  top: 100%;
-  background-color: white;
-  border-radius: 4px;
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  min-width: 150px;
-  z-index: 1000; /* Aumentar o z-index para garantir que o menu fique acima de outros elementos */
-  margin-top: 5px;
-  overflow: visible;
-  border: 1px solid #e5e7eb;
-}
-
-.dropdown-item {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  cursor: pointer;
-  transition: background-color 0.2s;
-  color: #374151;
+  justify-content: center;
+  width: 2rem; /* Or adjust to fit icons */
+  height: 2rem; /* Or adjust to fit icons */
 }
 
-.dropdown-item:hover {
-  background-color: #f9fafb;
+.action-button svg {
+  width: 1rem; /* Default icon size, matches size="16" */
+  height: 1rem; /* Default icon size, matches size="16" */
 }
 
-.dropdown-item.delete {
-  color: #ef4444;
+.action-button:hover {
+  background-color: #e5e7eb; /* Default hover background */
 }
 
-.dropdown-item.delete:hover {
-  background-color: #fee2e2;
+/* Specific hover styles similar to ObrasTable.vue */
+.view-button:hover {
+  background-color: #dbeafe; /* Light blue */
+  color: #1e40af; /* Dark blue */
+}
+
+.edit-button:hover {
+  background-color: #dbeafe; /* Light blue */
+  color: #1e40af; /* Dark blue */
+}
+
+.delete-button:hover {
+  background-color: #fee2e2; /* Light red */
+  color: #b91c1c; /* Dark red */
 }
 
 @media (min-width: 768px) {

--- a/src/components/entradaRecurso/EntradaRecursoTable.vue
+++ b/src/components/entradaRecurso/EntradaRecursoTable.vue
@@ -66,29 +66,21 @@
                 @click="viewEntradaRecurso(entradaRecurso)"
                 title="Visualizar"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                  <path d="M10 12.5a2.5 2.5 0 100-5 2.5 2.5 0 000 5z" />
-                  <path fill-rule="evenodd" d="M.664 10.59a1.651 1.651 0 010-1.186A10.004 10.004 0 0110 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0110 17c-4.257 0-7.893-2.66-9.336-6.41zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clip-rule="evenodd" />
-                </svg>
+                <IconView size="16" />
               </button>
               <button 
                 class="action-button edit-button" 
                 @click="editEntradaRecurso(entradaRecurso)"
                 title="Editar"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                  <path d="M5.433 13.917l1.262-3.155A4 4 0 017.58 9.42l6.92-6.918a2.121 2.121 0 013 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 01-.65-.65z" />
-                  <path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0010 3H4.75A2.75 2.75 0 002 5.75v9.5A2.75 2.75 0 004.75 18h9.5A2.75 2.75 0 0017 15.25V10a.75.75 0 00-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5z" />
-                </svg>
+                <IconEdit size="16" />
               </button>
               <button 
                 class="action-button delete-button" 
                 @click="deleteEntradaRecurso(entradaRecurso)"
                 title="Excluir"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                  <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
-                </svg>
+                <IconDelete size="16" />
               </button>
             </div>
           </td>
@@ -106,6 +98,9 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { EntradaRecurso } from '@/types/entrada-recurso.types'
+import IconView from '@/components/icons/IconView.vue';
+import IconEdit from '@/components/icons/IconEdit.vue';
+import IconDelete from '@/components/icons/IconDelete.vue';
 
 // Props
 const props = defineProps<{
@@ -265,7 +260,7 @@ const sortTable = (field: string) => {
 
 .action-buttons {
   display: flex;
-  gap: 0.5rem;
+  gap: 0; /* Changed from 0.5rem for consistency */
 }
 
 .action-button {

--- a/src/components/fontesPagadoras/FontesPagadorasTable.vue
+++ b/src/components/fontesPagadoras/FontesPagadorasTable.vue
@@ -67,27 +67,28 @@
               <span 
                 class="status-badge" 
                 :class="{ 'active': fonte.ativo, 'inactive': !fonte.ativo }"
-                @click="toggleStatus(fonte.id, !fonte.ativo)"
+                
               >
                 {{ fonte.ativo ? 'Ativo' : 'Inativo' }}
               </span>
             </td>
             <td>{{ formatDate(fonte.data_cadastro || fonte.created_at) }}</td>
             <td class="actions-cell">
-              <div class="actions-menu">
-                <button class="actions-button" @click="toggleMenu(fonte.id)">
-                  <IconEllipsis size="18" />
+              <div class="action-buttons">
+                <button
+                  class="action-button edit-button"
+                  @click="handleEdit(fonte.id)"
+                  title="Editar"
+                >
+                  <IconEdit size="16" />
                 </button>
-                <div v-if="activeMenu === fonte.id" class="actions-dropdown">
-                  <div class="dropdown-item" @click="handleEdit(fonte.id)">
-                    <IconEdit />
-                    <span>Editar</span>
-                  </div>
-                  <div class="dropdown-item delete" @click="handleDelete(fonte.id)">
-                    <IconDelete />
-                    <span>Excluir</span>
-                  </div>
-                </div>
+                <button
+                  class="action-button delete-button"
+                  @click="handleDelete(fonte.id)"
+                  title="Excluir"
+                >
+                  <IconDelete size="16" />
+                </button>
               </div>
             </td>
           </tr>
@@ -103,7 +104,7 @@
           <span 
             class="status-badge" 
             :class="{ 'active': fonte.ativo, 'inactive': !fonte.ativo }"
-            @click="toggleStatus(fonte.id, !fonte.ativo)"
+            
           >
             {{ fonte.ativo ? 'Ativo' : 'Inativo' }}
           </span>
@@ -122,12 +123,12 @@
         </div>
         
         <div class="mobile-card-actions">
-          <button class="mobile-card-button edit" @click="handleEdit(fonte.id)">
-            <IconEdit size="14" />
+          <button class="mobile-card-button edit" @click="handleEdit(fonte.id)" title="Editar">
+            <IconEdit size="20" />
             <span>Editar</span>
           </button>
-          <button class="mobile-card-button delete" @click="handleDelete(fonte.id)">
-            <IconDelete size="14" />
+          <button class="mobile-card-button delete" @click="handleDelete(fonte.id)" title="Excluir">
+            <IconDelete size="20" />
             <span>Excluir</span>
           </button>
         </div>
@@ -141,7 +142,7 @@ import { ref, computed, onMounted, onUnmounted } from 'vue'
 import type { FontePagadora, PaginationLinks } from '@/types/fontePagadora.types'
 import Pagination from '@/components/common/Pagination.vue'
 import IconSort from '@/components/icons/IconSort.vue'
-import IconEllipsis from '@/components/icons/IconEllipsis.vue'
+// IconEllipsis import removed
 import IconEdit from '@/components/icons/IconEdit.vue'
 import IconDelete from '@/components/icons/IconDelete.vue'
 
@@ -168,28 +169,8 @@ const emit = defineEmits<{
   (e: 'sort', field: string): void;
   (e: 'edit', fonteId: number): void;
   (e: 'delete', fonteId: number): void;
-  (e: 'toggle-status', fonteId: number, ativo: boolean): void;
+  
 }>()
-
-// Controle do menu de ações
-const activeMenu = ref<number | null>(null)
-const toggleMenu = (fonteId: number) => {
-  if (activeMenu.value === fonteId) {
-    activeMenu.value = null
-  } else {
-    activeMenu.value = fonteId
-  }
-}
-
-// Fechar o menu quando clicar fora dele
-const closeMenuOnClickOutside = (event: MouseEvent) => {
-  if (activeMenu.value !== null) {
-    const target = event.target as HTMLElement
-    if (!target.closest('.actions-menu')) {
-      activeMenu.value = null
-    }
-  }
-}
 
 // Estado para controlar a visualização mobile/desktop
 const isMobile = ref(false)
@@ -201,7 +182,7 @@ const checkScreenSize = () => {
 
 // Adicionar e remover os listeners quando o componente é montado/desmontado
 onMounted(() => {
-  document.addEventListener('click', closeMenuOnClickOutside)
+  // document.removeEventListener('click', closeMenuOnClickOutside) // Listener removed
   
   // Verificar o tamanho da tela inicialmente
   checkScreenSize()
@@ -211,24 +192,24 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
-  document.removeEventListener('click', closeMenuOnClickOutside)
+  // document.removeEventListener('click', closeMenuOnClickOutside) // Listener removed
   window.removeEventListener('resize', checkScreenSize)
 })
 
-// Ações do menu
+// Ações
 const handleEdit = (fonteId: number) => {
   emit('edit', fonteId)
-  activeMenu.value = null
+  // activeMenu.value = null // activeMenu removed
 }
 
 const handleDelete = (fonteId: number) => {
   emit('delete', fonteId)
-  activeMenu.value = null
+  // activeMenu.value = null // activeMenu removed
 }
 
-const toggleStatus = (fonteId: number, ativo: boolean) => {
-  emit('toggle-status', fonteId, ativo)
-}
+// const toggleStatus = (fonteId: number, ativo: boolean) => {
+//   emit('toggle-status', fonteId, ativo)
+// } // Function removed
 
 const handleSort = (field: string) => {
   emit('sort', field)
@@ -351,7 +332,7 @@ const formatDate = (dateString: string): string => {
   border-radius: 9999px;
   font-size: 0.75rem;
   font-weight: 500;
-  cursor: pointer;
+  cursor: pointer; /* Kept as it was, though click handler is removed */
 }
 
 .status-badge.active {
@@ -365,9 +346,8 @@ const formatDate = (dateString: string): string => {
 }
 
 .actions-cell {
-  width: 60px;
-  text-align: center;
-  position: relative;
+  width: 60px; 
+  text-align: center; 
 }
 
 .actions-header {
@@ -375,62 +355,45 @@ const formatDate = (dateString: string): string => {
   width: 60px;
 }
 
-.actions-menu {
-  position: relative;
-  display: inline-block;
+/* Styles for new desktop action buttons */
+.action-buttons {
+  display: flex;
+  gap: 0; 
+  justify-content: center; 
 }
 
-.actions-button {
+.action-button {
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
-  color: var(--color-text-secondary);
-}
-
-.actions-button:hover {
-  background-color: var(--color-gray-100);
-}
-
-.actions-dropdown {
-  position: absolute;
-  right: 0;
-  top: 100%;
-  z-index: 10;
-  background-color: white;
-  border-radius: 0.375rem;
-  box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-  min-width: 150px;
-  overflow: hidden;
-}
-
-.dropdown-item {
-  display: flex;
+  padding: 5px;
+  border-radius: 4px;
+  color: #6b7280; 
+  transition: all 0.2s;
+  display: inline-flex; 
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  cursor: pointer;
-  font-size: 0.875rem;
-  color: #1f2937; /* Texto mais escuro */
-  font-weight: 500;
+  justify-content: center;
+  width: 2rem; 
+  height: 2rem; 
 }
 
-.dropdown-item:hover {
-  background-color: var(--color-gray-50);
+.action-button.edit-button:hover {
+  background-color: #dbeafe; 
+  color: #1e40af;      
 }
 
-.dropdown-item.delete {
-  color: var(--color-danger);
+.action-button.delete-button:hover {
+  background-color: #fee2e2; 
+  color: #b91c1c;      
 }
 
-.dropdown-item.delete:hover {
-  background-color: #fee2e2;
+.action-button ::v-deep(svg) {
+  width: 1rem;  
+  height: 1rem; 
 }
 
+/* Styles for mobile card view action buttons */
 @media (max-width: 767px) {
-  
-  /* Exibimos cards no lugar da tabela em dispositivos móveis */
   .mobile-cards {
     display: flex;
     flex-direction: column;
@@ -498,12 +461,17 @@ const formatDate = (dateString: string): string => {
     gap: 0.25rem;
     padding: 0.375rem 0.75rem;
     border-radius: 0.375rem;
-    font-size: 0.75rem;
+    font-size: 0.75rem; /* For the span */
     font-weight: 600;
     cursor: pointer;
-    background-color: #f3f4f6;
-    color: #1f2937;
+    background-color: #f3f4f6; /* Base background */
+    color: #1f2937; /* Base text color */
     border: none;
+  }
+
+  .mobile-card-button ::v-deep(svg) {
+    width: 1.25rem; /* 20px */
+    height: 1.25rem; /* 20px */
   }
   
   .mobile-card-button.edit {

--- a/src/components/gastos/GastosTable.vue
+++ b/src/components/gastos/GastosTable.vue
@@ -75,19 +75,14 @@
                 @click="editGasto(gasto)"
                 title="Editar"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                  <path d="M5.433 13.917l1.262-3.155A4 4 0 017.58 9.42l6.92-6.918a2.121 2.121 0 013 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 01-.65-.65z" />
-                  <path d="M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0010 3H4.75A2.75 2.75 0 002 5.75v9.5A2.75 2.75 0 004.75 18h9.5A2.75 2.75 0 0017 15.25V10a.75.75 0 00-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5z" />
-                </svg>
+                <IconEdit size="16" />
               </button>
               <button 
                 class="action-button delete-button" 
                 @click="deleteGasto(gasto)"
                 title="Excluir"
               >
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="w-5 h-5">
-                  <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 006 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 10.23 1.482l.149-.022.841 10.518A2.75 2.75 0 007.596 19h4.807a2.75 2.75 0 002.742-2.53l.841-10.52.149.023a.75.75 0 00.23-1.482A41.03 41.03 0 0014 4.193V3.75A2.75 2.75 0 0011.25 1h-2.5zM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4zM8.58 7.72a.75.75 0 00-1.5.06l.3 7.5a.75.75 0 101.5-.06l-.3-7.5zm4.34.06a.75.75 0 10-1.5-.06l-.3 7.5a.75.75 0 101.5.06l.3-7.5z" clip-rule="evenodd" />
-                </svg>
+                <IconDelete size="16" />
               </button>
             </div>
           </td>
@@ -101,6 +96,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onUnmounted } from 'vue';
 import type { Gasto, PaginationMeta, PaginationLinks } from '@/types/gasto.types';
+import IconEdit from '@/components/icons/IconEdit.vue';
+import IconDelete from '@/components/icons/IconDelete.vue';
 
 const props = defineProps<{
   gastos: Gasto[];
@@ -203,7 +200,7 @@ th.sortable-header {
 }
 .action-buttons {
   display: flex;
-  gap: 0.5rem;
+  gap: 0; /* Changed from 0.5rem for consistency */
 }
 
 .action-button {
@@ -221,7 +218,10 @@ th.sortable-header {
   height: 2rem;
 }
 
-.action-button svg {
+/* Adjusted to target SVGs within components if necessary, though size prop should handle it. */
+/* This also ensures direct SVGs would still be styled if used. */
+.action-button svg, 
+.action-button ::v-deep(svg) {
   width: 1rem;
   height: 1rem;
 }

--- a/src/components/usuarios/UsersTable.vue
+++ b/src/components/usuarios/UsersTable.vue
@@ -63,31 +63,34 @@
             <td>{{ formatDate(user.created_at) }}</td>
             <td class="actions-cell" 
             :style="{ position: users.length === users.indexOf(user) + 1 ? 'absolute' : '', borderBottom: users.length === users.indexOf(user) + 1 ? 'none' : '' }">
-              <div class="actions-menu">
-                <button class="actions-button" @click="toggleMenu(user.id)">
-                  <IconEllipsis size="18" />
+              <div class="action-buttons">
+                <button
+                  class="action-button view-button"
+                  @click="handleView(user.id)"
+                  title="Visualizar"
+                >
+                  <IconView size="16" />
                 </button>
-                <div v-if="activeMenu === user.id" class="actions-dropdown">
-                    <div class="dropdown-item" @click="handleView(user.id)">
-                      <IconView />
-                      <span>Visualizar</span>
-                    </div>
-                    <div class="dropdown-item" @click="handleEdit(user.id)">
-                      <IconEdit />
-                      <span>Editar</span>
-                    </div>
-                    <div class="dropdown-item delete" @click="handleDelete(user.id)">
-                      <IconDelete />
-                      <span>Excluir</span>
-                    </div>
-                  </div>
+                <button
+                  class="action-button edit-button"
+                  @click="handleEdit(user.id)"
+                  title="Editar"
+                >
+                  <IconEdit size="16" />
+                </button>
+                <button
+                  class="action-button delete-button"
+                  @click="handleDelete(user.id)"
+                  title="Excluir"
+                >
+                  <IconDelete size="16" />
+                </button>
               </div>
             </td>
           </tr>
         </tbody>
       </table>
-      <!-- Div extra para garantir espaço para o menu de ações -->
-      <div class="table-spacer"></div>
+      <!-- <div class="table-spacer"></div> --> <!-- Removed as per instructions -->
     </div>
     
     <!-- Modal de confirmação de exclusão -->
@@ -114,7 +117,7 @@ import type { User, PaginationLinks } from '@/types/user.types'
 import Pagination from '@/components/common/Pagination.vue'
 import ConfirmationModal from '@/components/common/ConfirmationModal.vue'
 import IconSort from '@/components/icons/IconSort.vue'
-import IconEllipsis from '@/components/icons/IconEllipsis.vue'
+// IconEllipsis import removed
 import IconView from '@/components/icons/IconView.vue'
 import IconEdit from '@/components/icons/IconEdit.vue'
 import IconDelete from '@/components/icons/IconDelete.vue'
@@ -149,44 +152,24 @@ const emit = defineEmits<{
   (e: 'delete', userId: number): void;
 }>()
 
-// Controle do menu de ações
-const activeMenu = ref<number | null>(null)
-const toggleMenu = (userId: number) => {
-  if (activeMenu.value === userId) {
-    activeMenu.value = null
-  } else {
-    activeMenu.value = userId
-  }
-}
-
-// Fechar o menu quando clicar fora dele
-const closeMenuOnClickOutside = (event: MouseEvent) => {
-  if (activeMenu.value !== null) {
-    const target = event.target as HTMLElement
-    if (!target.closest('.actions-menu')) {
-      activeMenu.value = null
-    }
-  }
-}
-
 // Adicionar e remover o listener quando o componente é montado/desmontado
 onMounted(() => {
-  document.addEventListener('click', closeMenuOnClickOutside)
+  // document.addEventListener('click', closeMenuOnClickOutside) // Listener removed
 })
 
 onUnmounted(() => {
-  document.removeEventListener('click', closeMenuOnClickOutside)
+  // document.removeEventListener('click', closeMenuOnClickOutside) // Listener removed
 })
 
-// Ações do menu
+// Ações
 const handleView = (userId: number) => {
   router.push({ name: 'user-details', params: { id: userId.toString() } })
-  activeMenu.value = null
+  // activeMenu.value = null; // activeMenu removed
 }
 
 const handleEdit = (userId: number) => {
   router.push({ name: 'edit-user', params: { id: userId.toString() } })
-  activeMenu.value = null
+  // activeMenu.value = null; // activeMenu removed
 }
 
 const handleDelete = (userId: number) => {
@@ -196,7 +179,7 @@ const handleDelete = (userId: number) => {
     userToDelete.value = user
     showDeleteModal.value = true
   }
-  activeMenu.value = null
+  // activeMenu.value = null; // activeMenu removed
 }
 
 const confirmDelete = async () => {
@@ -358,67 +341,51 @@ const formatDate = (dateString: string): string => {
 .actions-cell {
   width: 80px;
   text-align: center;
-  position: relative;
+  /* position: relative; */ /* Removed as per instructions */
 }
 
-.actions-menu {
-  position: relative;
-  display: inline-block;
+/* New styles for desktop action buttons */
+.action-buttons {
+  display: flex;
+  gap: 0; /* For consistency */
+  justify-content: center; /* If actions-cell has text-align: center, this might not be strictly needed but is good practice */
 }
 
-.actions-button {
+.action-button {
   background: none;
   border: none;
-  color: #6b7280;
   cursor: pointer;
-  padding: 0.25rem;
-  border-radius: 0.25rem;
-}
-
-.actions-button:hover {
-  background-color: #f3f4f6;
-  color: #111827;
-}
-
-.actions-dropdown {
-  position: absolute;
-  right: 0;
-  z-index: 10;
-  width: 150px;
-  background-color: white;
-  border-radius: 0.375rem;
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-  padding: 0.5rem 0;
-  margin-top: 0.25rem;
-}
-
-.dropdown-item {
-  display: flex;
+  padding: 5px;
+  border-radius: 4px;
+  color: #6b7280; /* Default icon color */
+  transition: all 0.2s;
+  display: inline-flex;
   align-items: center;
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-  color: #4b5563;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
 }
 
-.dropdown-item:hover {
-  background-color: #f3f4f6;
+.action-button.view-button:hover {
+  background-color: #dbeafe;
+  color: #1e40af;
 }
-
-.dropdown-item.delete {
-  color: #ef4444;
+.action-button.edit-button:hover {
+  background-color: #dbeafe; /* Same as view, adjust if different design needed */
+  color: #1e40af;
 }
-
-.dropdown-item.delete:hover {
+.action-button.delete-button:hover {
   background-color: #fee2e2;
+  color: #b91c1c;
 }
 
-.dropdown-item svg {
-  margin-right: 0.5rem;
-  width: 16px;
-  height: 16px;
+/* SVG sizing within these buttons */
+.action-button ::v-deep(svg) { /* Or just .action-button svg if ::v-deep isn't needed */
+  width: 1rem; /* For size="16" */
+  height: 1rem;
 }
 
-.table-spacer {
-  height: 150px;
-}
+/* .table-spacer { */ /* Removed as per instructions */
+  /* height: 150px; */
+/* } */
 </style>


### PR DESCRIPTION
This commit updates the action buttons in various table components to ensure a consistent user experience.

Key changes include:

- Replaced dropdown menus and direct SVG icons with standardized Vue icon components (`IconView`, `IconEdit`, `IconDelete`) in table rows for desktop views.
- Ensured action buttons on mobile card views (where applicable) use an icon-plus-text format, consistent with `ObrasTable.vue`.
- Standardized styling for action buttons (icon-only on desktop, icon+text on mobile cards) including hover effects, padding, and colors.
- Added/Verified `title` attributes for all action buttons for improved accessibility (tooltips).
- Removed click functionality from status badges in `FontesPagadorasTable.vue`, making them purely informational.
- Cleaned up unused CSS and script logic related to old dropdown menus.
- Removed unnecessary `table-spacer` divs where dropdowns were removed.

Affected components:
- `ClientsTable.vue`
- `CategoriasGastosTable.vue`
- `EntradaRecursoTable.vue`
- `FontesPagadorasTable.vue`
- `GastosTable.vue`
- `UsersTable.vue`

This refactoring improves UI consistency and maintainability by using shared icon components and a unified design pattern for actions within tables.